### PR TITLE
generic: initial project repository with gadget snap code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# private configurations
+/config.mk
+
+# snapcraft artifacts
+parts/
+stage/
+prime/
+snap/
+*.snap
+
+# ubuntu-image artifacts
+/seed.manifest
+/snaps.manifest
+/*.img
+/*.img.xz
+
+# signed model assertions
+/model/*.model

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+-include config.mk
+
+ifeq ($(UC_MODEL_NAME),)
+$(error Model assertion name 'UC_MODEL_NAME' must be specified in config.mk)
+endif
+ifeq ($(SNAP_SIGNING_KEY),)
+$(error No siging key 'SNAP_SIGNING_KEY' is specified)
+endif
+
+GADGET_DIR  ?= gadget
+KERNEL_DIR  ?= kernel
+LOCAL_SNAPS += $(wildcard $(foreach d,$(GADGET_DIR) $(KERNEL_DIR),$d/*.snap))
+
+.PHONY: all clean
+
+all: model/$(UC_MODEL_NAME).model
+	ubuntu-image snap $< $(foreach snap,$(LOCAL_SNAPS),--snap $(snap))
+
+clean:
+	rm -f seed.manifest snaps.manifest *.img *.img.xz
+	rm -f model/$(UC_MODEL_NAME).model
+
+.SUFFIXES: .json .model
+
+%.model: %.json
+	sed -e 's/<AuthorityId>/$(SNAP_DEVELOPER_ID)/'                  \
+	    -e 's/<BrandId>/$(SNAP_DEVELOPER_ID)/'                      \
+	    -e 's/<Model>/$(basename $(notdir $@))/'                    \
+	    -e 's/<AssertionCreationTime>/'`date -Iseconds --utc`'/'    \
+	    $< | snap sign -k $(SNAP_SIGNING_KEY) > $@

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ifeq ($(UC_MODEL_NAME),)
 $(error Model assertion name 'UC_MODEL_NAME' must be specified in config.mk)
 endif
 ifeq ($(SNAP_SIGNING_KEY),)
-$(error No siging key 'SNAP_SIGNING_KEY' is specified)
+$(error No signing key 'SNAP_SIGNING_KEY' is specified)
 endif
 
 GADGET_DIR  ?= gadget

--- a/gadget/Makefile
+++ b/gadget/Makefile
@@ -1,0 +1,25 @@
+# filtered list of modules to be included in the signed EFI grub image
+GRUB_MODULES = \
+	ext2 \
+	loopback \
+	linux \
+	multiboot \
+	part_gpt \
+
+all:
+	dd if=$(SNAPCRAFT_STAGE)/usr/lib/grub/i386-pc/boot.img of=pc-boot.img bs=440 count=1
+	/bin/echo -n -e '\x90\x90' | dd of=pc-boot.img seek=102 bs=1 conv=notrunc
+	grub-mkimage -d $(SNAPCRAFT_STAGE)/usr/lib/grub/x86_64-efi/ -O x86_64-efi -o pc-core.img -p '(,gpt2)/EFI/ubuntu' $(GRUB_MODULES)
+	# The first sector of the core image requires an absolute pointer to the
+	# second sector of the image.  Since this is always hard-coded, it means our
+	# BIOS boot partition must be defined with an absolute offset.  The
+	# particular value here is 2049, or 0x01 0x08 0x00 0x00 in little-endian.
+	/bin/echo -n -e '\x01\x08\x00\x00' | dd of=pc-core.img seek=500 bs=1 conv=notrunc
+
+install:
+	mkdir -p $(DESTDIR)/grub/
+	install -m 644 pc-boot.img pc-core.img $(DESTDIR)/grub/
+	install -m 644 $(SNAPCRAFT_STAGE)/usr/lib/shim/shimx64.efi.signed $(DESTDIR)/grub/shim.efi.signed
+	install -m 644 $(SNAPCRAFT_STAGE)/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed $(DESTDIR)/grub/grubx64.efi
+	install -m 644 $(SNAPCRAFT_STAGE)/usr/lib/shim/mmx64.efi $(DESTDIR)/grub/mmx64.efi
+	install -m 644 grub.conf $(DESTDIR)/

--- a/gadget/gadget.yaml
+++ b/gadget/gadget.yaml
@@ -1,0 +1,42 @@
+volumes:
+  pc:
+    bootloader: grub
+    structure:
+      - name: mbr
+        type: mbr
+        size: 440
+        update:
+          edition: 1
+        content:
+          - image: grub/pc-boot.img
+
+      - name: BIOS Boot
+        type: DA,21686148-6449-6E6F-744E-656564454649
+        size: 1M
+        offset: 1M
+        offset-write: mbr+92
+        update:
+          edition: 1
+        content:
+          - image: grub/pc-core.img
+
+      - name: EFI System
+        type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+        filesystem: vfat
+        filesystem-label: system-boot
+        size: 50M
+        update:
+          edition: 1
+        content:
+          - source: grub/grubx64.efi
+            target: EFI/boot/grubx64.efi
+          - source: grub/shim.efi.signed
+            target: EFI/boot/bootx64.efi
+          - source: grub/mmx64.efi
+            target: EFI/boot/mmx64.efi
+          - source: grub.conf
+            target: EFI/ubuntu/grub.conf
+          - source: usr/lib/grub/x86_64-efi/
+            target: EFI/ubuntu/x86_64-efi/
+          - source: boot/acrn/acrn.bin
+            target: EFI/ubuntu/acrn/acrn.bin

--- a/gadget/grub.conf
+++ b/gadget/grub.conf
@@ -1,0 +1,49 @@
+set default=0
+set timeout=3
+
+insmod part_gpt
+insmod ext2
+
+if [ -s $prefix/grubenv ]; then
+  load_env
+fi
+
+# allow customizing the menu entry via grubenv
+if [ -z "$snap_menuentry" ]; then
+    set snap_menuentry="Ubuntu Core 16"
+fi
+
+if [ "$snap_mode" = "try" ]; then
+    # a new core or kernel got installed
+    set snap_mode="trying"
+    save_env snap_mode
+
+    if [ x"$snap_try_core" != x"" ]; then
+        set snap_core="$snap_try_core"
+    fi
+    if [ x"$snap_try_kernel" != x"" ]; then
+        set snap_kernel="$snap_try_kernel"
+    fi
+elif [ "$snap_mode" = "trying" ]; then
+    # nothing cleared the "trying snap" so the boot failed
+    # we clear the mode and boot normally
+    set snap_mode=""
+    save_env snap_mode
+fi
+
+set label="writable"
+set cmdline="root=LABEL=$label snap_core=$snap_core snap_kernel=$snap_kernel ro net.ifnames=0 init=/lib/systemd/systemd console=ttyS0 console=tty1 panic=-1"
+
+menuentry "$snap_menuentry" {
+    search --label $label --set=writable
+    loopback loop ($writable)/system-data/var/lib/snapd/snaps/$snap_kernel
+    linux (loop)/kernel.img $cmdline
+    initrd (loop)/initrd.img
+}
+
+menuentry "ACRN Hypervisor on $snap_menuentry" {
+    search --label $label --set=writable
+    loopback loop ($writable)/system-data/var/lib/snapd/snaps/$snap_kernel
+    multiboot2 /efi/ubuntu/acrn/acrn.bin $cmdline
+    module2 (loop)/kernel.img Linux_bzImage
+}

--- a/gadget/snapcraft.yaml
+++ b/gadget/snapcraft.yaml
@@ -1,0 +1,59 @@
+name: acrn
+version: 2.3.0-core18
+type: gadget
+base: core18
+summary: ACRN PC gadget
+description: |
+  PC gadget for ACRN devices.
+grade: devel
+confinement: strict
+
+apps:
+  acrn-dm:
+    environment:
+      LD_LIBRARY_PATH: $SNAP/usr/lib/x86_64-linux-gnu:$SNAP/lib/x86_64-linux-gnu:LD_LIBRARY_PATH
+    command:
+      usr/bin/acrn-dm
+
+  acrnctl:
+    command:
+      usr/bin/acrnctl
+
+parts:
+  build-environ:
+    # Install build tools and dependencies required by ACRN development
+    # https://projectacrn.github.io/2.3/getting-started/building-from-source.html
+    build-packages: [ gcc, git, make, libssl-dev, libpciaccess-dev, uuid-dev,
+                      libsystemd-dev, libevent-dev, libxml2-dev, libusb-1.0-0-dev,
+                      python3, python3-pip, libblkid-dev, e2fslibs-dev, pkg-config,
+                      libnuma-dev, liblz4-tool, flex, bison ]
+    plugin: python
+    python-packages: [ kconfiglib ]
+    stage-packages: [ grub-efi-amd64-signed, grub-pc-bin, shim-signed ]
+    prime: [ usr/lib/grub/x86_64-efi/ ]
+
+  iasl:
+    after: [ build-environ ]
+    plugin: make
+    source: https://acpica.org/sites/acpica/files/acpica-unix-20191018.tar.gz
+    make-parameters: [ iasl ]
+    organize:
+      usr/bin/iasl: usr/sbin/iasl
+    prime:
+      - usr/sbin/iasl
+
+  acrn:
+    after: [ iasl ]
+    plugin: make
+    source: https://github.com/projectacrn/acrn-hypervisor.git
+    source-tag: v2.3
+    stage-packages: [ libpciaccess-dev, libusb-1.0-0 ]
+    override-prime: |
+      snapcraftctl prime
+      install -D $SNAPCRAFT_PART_BUILD/build/hypervisor/acrn.bin boot/acrn/acrn.bin
+
+  grub:
+    after: [ build-environ ]
+    build-packages: [ grub-common ]
+    plugin: make
+    source: .

--- a/model/acrn-uc18-amd64.json
+++ b/model/acrn-uc18-amd64.json
@@ -1,0 +1,12 @@
+{
+    "type": "model",
+    "series": "16",
+    "authority-id": "<AuthorityId>",
+    "brand-id": "<BrandId>",
+    "model": "<Model>",
+    "architecture": "amd64",
+    "timestamp": "<AssertionCreationTime>",
+    "base": "core18",
+    "gadget": "acrn",
+    "kernel": "pc-kernel"
+}

--- a/template/config.mk
+++ b/template/config.mk
@@ -1,0 +1,3 @@
+SNAP_DEVELOPER_ID   = <Your developer ID>
+SNAP_SIGNING_KEY    = <Your snap signing key name>
+UC_MODEL_NAME       = <Your model assertion name>


### PR DESCRIPTION
This commit defines the project directories for the ACRN snap, and the initial gadget snap with ACRN binaries built-in.

Signed-off-by: Tonny Tzeng <tonny.tzeng@intel.com>