### PR TITLE
Makefile: put generated image in a folder named after the model 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ snap/
 /snaps.manifest
 /*.img
 /*.img.xz
+images/*
 
 # signed model assertions
 /model/*.model

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,11 @@ LOCAL_SNAPS += $(wildcard $(foreach d,$(GADGET_DIR) $(KERNEL_DIR),$d/*.snap))
 .PHONY: all clean
 
 all: model/$(UC_MODEL_NAME).model
-	ubuntu-image snap $< $(foreach snap,$(LOCAL_SNAPS),--snap $(snap))
+	ubuntu-image snap $< $(foreach snap,$(LOCAL_SNAPS),--snap $(snap)) \
+		-O images/$(UC_MODEL_NAME)
 
 clean:
-	rm -f seed.manifest snaps.manifest *.img *.img.xz
+	rm -fr images/$(UC_MODEL_NAME)
 	rm -f model/$(UC_MODEL_NAME).model
 
 .SUFFIXES: .json .model


### PR DESCRIPTION
Re-use the model name to create a folder where the Ubuntu Core image
generated by 'ubuntu-image' will be placed.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>