### PR TITLE
Private Config: only set variables if not already set

### DIFF
--- a/template/config.mk
+++ b/template/config.mk
@@ -1,3 +1,3 @@
-SNAP_DEVELOPER_ID   = <Your developer ID>
-SNAP_SIGNING_KEY    = <Your snap signing key name>
-UC_MODEL_NAME       = <Your model assertion name>
+SNAP_DEVELOPER_ID   ?= <Your developer ID>
+SNAP_SIGNING_KEY    ?= <Your snap signing key name>
+UC_MODEL_NAME       ?= <Your model assertion name>


### PR DESCRIPTION
Update the template for storing one's private configuration items
to only set the variable if *not* already set. This allows for
an easily overwriting them from the command-line, e.g.:

   UC_MODEL_NAME=my-alt-model make

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>