### PR TITLE
gadget: move to 2.4 release and add patching mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # private configurations
 /config.mk
 
+# staging patches
+/gadget/staging/*/*.patch
+
 # snapcraft artifacts
 parts/
 stage/
@@ -9,11 +12,10 @@ snap/
 *.snap
 
 # ubuntu-image artifacts
-/seed.manifest
-/snaps.manifest
-/*.img
-/*.img.xz
-images/*
+/images/*/seed.manifest
+/images/*/snaps.manifest
+/images/*/*.img
+/images/*/*.img.xz
 
 # signed model assertions
 /model/*.model

--- a/gadget/snapcraft.yaml
+++ b/gadget/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: acrn
-version: 2.3.0-core20
+version: 2.4.0-core20
 type: gadget
 base: core20
 summary: ACRN PC gadget
@@ -20,15 +20,20 @@ apps:
       usr/bin/acrnctl
 
 parts:
+  staging:
+    plugin: dump
+    source: staging
+    prime: [ -* ]
+
   build-environ:
     # Install build tools and dependencies required by ACRN development
     # https://projectacrn.github.io/2.3/getting-started/building-from-source.html
     build-packages: [ gcc, git, make, libssl-dev, libpciaccess-dev, uuid-dev,
                       libsystemd-dev, libevent-dev, libxml2-dev, libusb-1.0-0-dev,
                       python3, python3-pip, libblkid-dev, e2fslibs-dev, pkg-config,
-                      libnuma-dev, liblz4-tool, flex, bison ]
+                      libnuma-dev, liblz4-tool, flex, bison, xsltproc ]
     plugin: python
-    python-packages: [ kconfiglib ]
+    python-packages: [ lxml, xmlschema ]
     stage-packages: [ grub-efi-amd64-signed, grub-pc-bin, shim-signed ]
     prime: [ -* ]
 
@@ -43,11 +48,17 @@ parts:
       - usr/sbin/iasl
 
   acrn:
-    after: [ iasl ]
+    after: [ iasl, staging ]
     plugin: make
     source: https://github.com/projectacrn/acrn-hypervisor.git
-    source-tag: v2.3
-    make-parameters: [ RELEASE=0 ]
+    source-branch: release_2.4
+    override-build: |
+      for patch in $SNAPCRAFT_STAGE/acrn/*.patch; do
+        if [ -f $patch ]; then
+          git apply $patch;
+        fi;
+      done
+      snapcraftctl build
     stage-packages: [ libpciaccess-dev, libusb-1.0-0 ]
     override-prime: |
       snapcraftctl prime

--- a/gadget/staging/acrn/README.md
+++ b/gadget/staging/acrn/README.md
@@ -1,0 +1,5 @@
+## Staging patches for ACRN gadget snap
+
+Patches in this folder will be applied to the ACRN deliverables to be packaged
+in the ACRN gadget snap. However, the added patches won't be tracked in the
+containing gadget repository.


### PR DESCRIPTION
This commit upgrades the gadget to ACRN 2.4 release, and adds a patching mechanism to include the staging patches for fixing the following issues:

* [broken parallel build](https://github.com/projectacrn/acrn-hypervisor/issues/5874)
* redirect SOS kernel startup messages to vm_console  [(1)](https://github.com/tttech-industrial-buchsbaum/acrn-hypervisor/blob/debian/master/debian/patches/0008-hv-add-vm_console-command-line-parameter.patch)
* prevent larger initrd corrupted by bzImage loaded by ACRN hypervisor  [(1)](https://github.com/tttech-industrial-buchsbaum/acrn-hypervisor/blob/debian/master/debian/patches/0009-hv-vm_load-avoid-overwriting-source-images.patch)  [(2)](https://github.com/tttech-industrial-buchsbaum/acrn-hypervisor/blob/debian/master/debian/patches/0011-hv-boot-enhance-Linux-boot-header-structure.patch)  [(3)](https://github.com/tttech-industrial-buchsbaum/acrn-hypervisor/blob/debian/master/debian/patches/0012-vboot_info-load-ramdisk-at-highest-possible-memory-l.patch)

Signed-off-by: Tonny Tzeng <tonny.tzeng@intel.com>