### PR TITLE
gadget, kernel, uos: complete BKC for running ACRN Service VM in Ubuntu Core 20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # staging patches
 /gadget/staging/*/*.patch
 
+# drop-in user VM OS images
+/uos/images/*.img.xz
+
 # snapcraft artifacts
 parts/
 stage/

--- a/Makefile
+++ b/Makefile
@@ -11,15 +11,46 @@ GADGET_DIR  ?= gadget
 KERNEL_DIR  ?= kernel
 LOCAL_SNAPS += $(wildcard $(foreach d,$(GADGET_DIR) $(KERNEL_DIR),$d/*.snap))
 
-.PHONY: all clean
+.PHONY: all gadget kernel image clean
 
-all: model/$(UC_MODEL_NAME).model
+all: gadget kernel image
+
+image: model/$(UC_MODEL_NAME).model
 	ubuntu-image snap $< $(foreach snap,$(LOCAL_SNAPS),--snap $(snap)) \
 		-O images/$(UC_MODEL_NAME)
 
-clean:
+clean-targets :=
+clean-objs    := model/$(UC_MODEL_NAME).model
+
+# Usage: $(eval $(call add-snap-rule, <type>, <folder>, <prefix>, <arguments>))
+#   <type>      : [ gadget | kernel ]
+#   <folder>    : folder containing snapcraft.yaml file
+#   <prefix>    : prefix before launching snapcraft command
+#   <arguments> : arguments to pass to snapcraft command
+define add-snap-rule =
+snapname := $(filter-out name:,$(shell grep 'name:' $2/snapcraft.yaml))
+snapver  := $(filter-out version:,$(shell grep 'version:' $2/snapcraft.yaml))
+snapfile := $2/$$(snapname)_$$(snapver)_amd64.snap
+
+$1: $$(snapfile)
+$$(snapfile): $2/snapcraft.yaml
+	@echo 'Building $$@ ...'
+	cd $2; $3snapcraft $4
+
+.PHONY: $1-clean
+clean-objs += $$(snapfile)
+clean-targets += $1-clean
+
+$1-clean:
+	cd $2; $3snapcraft clean $4
+endef
+
+$(eval $(call add-snap-rule, gadget, $(GADGET_DIR),,))
+$(eval $(call add-snap-rule, kernel, $(KERNEL_DIR),,--destructive-mode))
+
+clean: $(clean-targets)
 	rm -fr images/$(UC_MODEL_NAME)
-	rm -f model/$(UC_MODEL_NAME).model
+	rm -f $(clean-objs)
 
 .SUFFIXES: .json .model
 

--- a/gadget/acrn.cfg
+++ b/gadget/acrn.cfg
@@ -37,7 +37,12 @@ fi
 
 if [ -e ($root)/EFI/acrn/acrn.bin ]; then
 menuentry "Run ACRN on Ubuntu Core 20" {
-    multiboot2 ($root)/EFI/acrn/acrn.bin
-    module2 $prefix/bzImage Linux_bzImage snapd_recovery_mode=run $cmdline
+    search --no-floppy --set=data_fs --label ubuntu-data
+    if [ -n "$data_fs" ]; then
+        loopback loop ($data_fs)/system-data/var/lib/snapd/snaps/acrn-kernel_*.snap
+        multiboot --quirk-modules-after-kernel ($root)/EFI/acrn/acrn.out
+        module (loop)/bzImage Linux_bzImage snapd_recovery_mode=run $cmdline apparmor=0
+        module (loop)/initrd.img Linux_initrd
+    fi
 }
 fi

--- a/gadget/gadget.yaml
+++ b/gadget/gadget.yaml
@@ -24,7 +24,7 @@ volumes:
         role: system-seed
         type: EF,C12A7328-F81F-11D2-BA4B-00A0C93EC93B
         filesystem: vfat
-        size: 700M
+        size: 1500M
         update:
           edition: 1
         content:
@@ -39,7 +39,7 @@ volumes:
         role: system-boot
         type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
         filesystem: ext4
-        size: 700M
+        size: 50M
         update:
           edition: 1
         content:
@@ -64,4 +64,4 @@ volumes:
         role: system-data
         type: 83,0FC63DAF-8483-4772-8E79-3D69D8477DE4
         filesystem: ext4
-        size: 1G
+        size: 1500M

--- a/gadget/snapcraft.yaml
+++ b/gadget/snapcraft.yaml
@@ -14,6 +14,10 @@ apps:
       LD_LIBRARY_PATH: $SNAP/usr/lib/x86_64-linux-gnu:$SNAP/lib/x86_64-linux-gnu:LD_LIBRARY_PATH
     command:
       usr/bin/acrn-dm
+    plugs:
+      - cifs-mount
+      - hugepages-control
+      - network-bind
 
   acrnctl:
     command:
@@ -52,6 +56,7 @@ parts:
     plugin: make
     source: https://github.com/projectacrn/acrn-hypervisor.git
     source-branch: release_2.4
+    make-parameters: [ ASL_COMPILER=/snap/acrn/current/usr/sbin/iasl ]
     override-build: |
       for patch in $SNAPCRAFT_STAGE/acrn/*.patch; do
         if [ -f $patch ]; then

--- a/kernel/snapcraft.yaml
+++ b/kernel/snapcraft.yaml
@@ -1,0 +1,64 @@
+# For core20, to cheat snapcraft you need confusingly add
+#   build-base: core18
+# so snapcraft treats this is v1 plugin
+#
+# Ubuntu kernels are usually created first as debian packages, then snap is
+# built from binaries. When doing something custom, a snapcraft plugin
+# should be set up in snap/plugins/ folder.
+# For core20:
+#     https://github.com/kubiko/snapcraft-kernel-plugin
+
+name: acrn-kernel
+version: 2.3.0-uc20
+type: kernel
+build-base: core18
+summary: ACRN kernel
+description: |
+  Linux kernel for running ACRN service VM
+grade: devel
+confinement: strict
+
+parts:
+  build-environ:
+    plugin: nil
+    stage-packages: [ linux-firmware ]
+    organize:
+      lib/firmware: firmware
+    prime: [ firmware ]
+
+  kernel:
+    after: [ build-environ ]
+    plugin: kernel
+    source: https://github.com/projectacrn/acrn-kernel
+    source-type: git
+    source-tag: v2.3
+    kernel-with-firmware: false
+    kernel-build-efi-image: true
+    kernel-initrd-core-base: core20
+    kconfigfile: $SNAPCRAFT_PART_BUILD/kernel_config_uefi_sos
+    kconfigs:
+      - CONFIG_SECURITY_APPARMOR=y
+      - CONFIG_STRICT_DEVMEM=y
+      - CONFIG_DEFAULT_SECURITY_APPARMOR=y
+      - CONFIG_CC_STACKPROTECTOR=y
+      - CONFIG_CC_STACKPROTECTOR_STRONG=y
+      - CONFIG_DEBUG_RODATA=y
+      - CONFIG_DEBUG_SET_MODULE_RONX=y
+      - CONFIG_ENCRYPTED_KEYS=y
+      - CONFIG_DEVPTS_MULTIPLE_INSTANCES=y
+      - CONFIG_AUTOFS4_FS=y
+      - CONFIG_VIRTIO_BLK=y
+      - CONFIG_SECURITY_SELINUX=n
+    build-packages: [ bison, cpio, dpkg-dev, flex, libssl-dev ]
+    stage:
+      - bzImage*
+      - config-*
+      - initrd*
+      - kernel.efi
+      - modules
+      - System.map-*
+      - -modules/*/build
+      - -modules/*/source
+    override-prime: |
+      snapcraftctl prime
+      ln -f bzImage-* bzImage

--- a/model/acrn-uc20-amd64.json
+++ b/model/acrn-uc20-amd64.json
@@ -14,7 +14,7 @@
             "type": "gadget"
         },
         {
-            "name": "pc-kernel",
+            "name": "acrn-kernel",
             "type": "kernel"
         },
         {

--- a/uos/images/README.md
+++ b/uos/images/README.md
@@ -1,0 +1,4 @@
+## XZ-compressed OS image for ACRN user VM
+
+Drop in the XZ-compressed OS image in this folder to be packaged as a snap
+for running the user VM on ACRN.

--- a/uos/launch.sh
+++ b/uos/launch.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Copyright (C) 2021 Intel Corporation.
+# SPDX-License-Identifier: BSD-3-Clause
+
+PATH=$PATH:/snap/bin
+
+img=uos.img
+
+if [ ! -f $SNAP_COMMON/$img ]; then
+    echo 'Setting up user VM image at' $SNAP_COMMON/$img
+    $SNAP_NAME.xzcat $SNAP/uos/$img.xz > $SNAP_COMMON/$img
+fi
+
+offline_path="/sys/class/vhm/acrn_vhm"
+# Check the device file of /dev/acrn_hsm to determine the offline_path
+if [ -e "/dev/acrn_hsm" ]; then
+offline_path="/sys/class/acrn/acrn_hsm"
+fi
+
+function launch_uos()
+{
+mac=$(cat /sys/class/net/e*/address)
+vm_name=vm$1
+mac_seed=${mac:9:8}-${vm_name}
+
+#check if the vm is running or not
+vm_ps=$(pgrep -a -f acrn.acrn-dm)
+result=$(echo $vm_ps | grep -w "${vm_name}")
+if [[ "$result" != "" ]]; then
+  echo "$vm_name is running, can't create twice!"
+  exit
+fi
+
+#logger_setting, format: logger_name,level; like following
+logger_setting="--logger_setting console,level=4;kmsg,level=3;disk,level=5"
+
+#for pm by vuart setting
+pm_channel="--pm_notify_channel uart "
+pm_by_vuart="--pm_by_vuart pty,/run/acrn/life_mngr_"$vm_name
+pm_vuart_node=" -s 1:0,lpc -l com2,/run/acrn/life_mngr_"$vm_name
+
+#for memsize setting
+mem_size=4096M
+
+acrn.acrn-dm -A -m $mem_size -s 0:0,hostbridge \
+  -s 5,virtio-console,@stdio:stdio_port \
+  -s 6,virtio-hyper_dmabuf \
+  -s 3,virtio-blk,$SNAP_COMMON/$img \
+  -s 4,virtio-net,tap0 \
+  -s 7,virtio-rnd \
+  --ovmf /snap/acrn/current/usr/share/acrn/bios/OVMF.fd \
+  --mac_seed $mac_seed \
+  $vm_name
+}
+
+# offline SOS CPUs except BSP before launch UOS
+for i in `ls -d /sys/devices/system/cpu/cpu[1-99]`; do
+        online=`cat $i/online`
+        idx=`echo $i | tr -cd "[1-99]"`
+        echo cpu$idx online=$online
+        if [ "$online" = "1" ]; then
+            echo 0 > $i/online
+            # during boot time, cpu hotplug may be disabled by pci_device_probe during a pci module insmod
+            while [ "$online" = "1" ]; do
+                sleep 1
+                echo 0 > $i/online
+                online=`cat $i/online`
+            done
+            echo $idx > ${offline_path}/offline_cpu
+        fi
+done
+
+launch_uos 1

--- a/uos/snapcraft.yaml
+++ b/uos/snapcraft.yaml
@@ -1,0 +1,35 @@
+name: acrn-uos
+base: core20
+summary: ACRN User VM
+description: |
+  User VM to be launched on ACRN
+grade: devel
+confinement: devmode
+adopt-info: uos
+
+apps:
+  launch:
+    command: uos/launch.sh
+    plugs: [ network-control ]
+  xzcat:
+    environment:
+      LD_LIBRARY_PATH: $SNAP/lib/x86_64-linux-gnu:LD_LIBRARY_PATH
+    command: usr/bin/xzcat
+
+parts:
+  environ:
+    plugin: nil
+    stage-packages: [ xz-utils, liblzma5 ]
+
+  uos:
+    after: [ environ ]
+    plugin: dump
+    source: .
+    override-prime: |
+      set -ex
+      xzimg=$(basename `ls $SNAPCRAFT_PART_SRC/images/*.img.xz`)
+      snapcraftctl set-version ${xzimg%.img.xz}
+      mkdir -p uos
+      sed -e 's/uos.img/'${xzimg%.xz}'/1' $SNAPCRAFT_PART_SRC/launch.sh > uos/launch.sh
+      chmod a+rx uos/launch.sh
+      cp $SNAPCRAFT_PART_SRC/images/${xzimg} uos/


### PR DESCRIPTION
This commit completes the gadget, kernel, and the User OS snaps for running VMs on ACRN.

Signed-off-by: Tonny Tzeng <tonny.tzeng@intel.com>