### PR TITLE
generic: add logic to define snapcraft build dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,14 @@ clean-objs    := model/$(UC_MODEL_NAME).model
 #   <prefix>    : prefix before launching snapcraft command
 #   <arguments> : arguments to pass to snapcraft command
 define add-snap-rule =
+snap-deps :=
+-include $2/depends.mk
 snapname := $(filter-out name:,$(shell grep 'name:' $2/snapcraft.yaml))
 snapver  := $(filter-out version:,$(shell grep 'version:' $2/snapcraft.yaml))
 snapfile := $2/$$(snapname)_$$(snapver)_amd64.snap
 
 $1: $$(snapfile)
-$$(snapfile): $2/snapcraft.yaml
+$$(snapfile): $$(addprefix $2/,snapcraft.yaml $$(snap-deps))
 	@echo 'Building $$@ ...'
 	cd $2; $3snapcraft $4
 

--- a/gadget/depends.mk
+++ b/gadget/depends.mk
@@ -1,0 +1,1 @@
+snap-deps := Makefile gadget.yaml acrn.cfg


### PR DESCRIPTION
This commit extends the `add-snap-rule` macro in the Makefile to allow the caller specifies the build dependencies. For example, changes in `gadget.yaml' should also trigger snap rebuild.

Signed-off-by: Tonny Tzeng <tonny.tzeng@intel.com>